### PR TITLE
Enable Future Parser Support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,3 @@
+** v0.0.2
+
+- 2018-03-06 future-parser support - JDF

--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name    '3dna-nrpe'
-version '0.0.1'
+version '0.0.2'
 source 'git://github.com/3dna/3dna-nrpe'
 author '3dna Corp'
 license 'Apache License, Version 2.0'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,7 +22,8 @@ class nrpe::params {
       $extra_packages = ['nagios-plugins']
       $service_name = 'nagios-nrpe-server'
       $plugin_path = '/usr/lib/nagios/plugins'
-      $_dist_release = scanf("${::lsbdistrelease}", "%i")
+      $_lsbdistrelease_int = scanf("${::lsbdistrelease}", "%i")
+      $_dist_release = $_lsbdistrelease_int[0]
 
       case $::operatingsystem {
         'Ubuntu': {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,12 +22,13 @@ class nrpe::params {
       $extra_packages = ['nagios-plugins']
       $service_name = 'nagios-nrpe-server'
       $plugin_path = '/usr/lib/nagios/plugins'
+      $_dist_release = scanf("${::lsbdistrelease}", "%i")
 
       case $::operatingsystem {
         'Ubuntu': {
           # in 13.04 the check_linux_raid was removed from nagios-plugins-standard,
           # renamed to check_raid, and moved into nagios-plugins-contrib. le SIGH
-          if ($lsbmajdistrelease >= 13) {
+          if ($_dist_release >= 13) {
             $check_raid_plugin = 'check_raid'
             $check_raid_package = 'nagios-plugins-contrib'
           } else {


### PR DESCRIPTION
This PR updates the module to enable future-parser support.

Resolves:

```
 Comparison of: String >= Integer, is not possible. Caused by 'A String is not comparable to a non String'.
```

Error experienced: http://ox1.central.prd.useast1.3dna.io/project/nb-fleet/execution/show/135261

/cc @jperez3 /cc https://github.com/3dna/puppet/pull/284