### PR TITLE
[future] Ensure octal file mode for plugins

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -49,12 +49,12 @@ define nrpe::plugin (
     true: {
       $owner  = $nrpe::params::nrpe_owner
       $group = $nrpe::params::nrpe_group
-      $mode  = 0700
+      $mode  = '0700'
     }
     default: {
       $owner  = undef
       $group = undef
-      $mode  = 0755
+      $mode  = '0755'
     }
   }
 


### PR DESCRIPTION
This commit updates the default file permissions to adhere to the octal requirements of the future parser in Puppet.